### PR TITLE
[012-REVIEW-API] Review 삭제, 조회, 수정 구현 및 접근 권한 부여

### DIFF
--- a/src/main/java/com/zerobase/tablereservation/common/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/tablereservation/common/config/SecurityConfig.java
@@ -18,8 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Slf4j
 @Configuration
+@EnableMethodSecurity(securedEnabled = true)
 @EnableWebSecurity
-@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -35,14 +35,13 @@ public class SecurityConfig {
                     auth -> auth
                             .requestMatchers("/auth/**").permitAll()
                             .requestMatchers("/v3/**", "/swagger-ui/**").permitAll()
-                            .requestMatchers("/restaurant-manage/**").hasAuthority("MANAGER")
+                            .requestMatchers("/restaurant-manage/**").hasRole("MANAGER")
                             .requestMatchers("/restaurant-search/**").permitAll()
-                            .requestMatchers("/reservation").hasAuthority("CUSTOMER")
-                            .requestMatchers("/reservation-manage").hasAuthority("MANAGER")
-                            .requestMatchers("/reservation/**").hasAuthority("CUSTOMER")
-                            .requestMatchers("/review/**").hasAnyAuthority(new String[]{"CUSTOMER", "MANAGER"})
+                            .requestMatchers("/reservation").hasRole("CUSTOMER")
+                            .requestMatchers("/reservation-manage").hasRole("MANAGER")
+                            .requestMatchers("/reservation/**").hasRole("CUSTOMER")
+                            .requestMatchers("/review/**").hasAnyRole("CUSTOMER", "MANAGER")
                             .anyRequest().denyAll()
-
             ).addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 

--- a/src/main/java/com/zerobase/tablereservation/common/constant/Authority.java
+++ b/src/main/java/com/zerobase/tablereservation/common/constant/Authority.java
@@ -1,16 +1,6 @@
 package com.zerobase.tablereservation.common.constant;
 
 public enum Authority {
-    ROLE_MANAGER{
-        @Override
-        public String toString() {
-            return "MANAGER";
-        }
-    },
-    ROLE_CUSTOMER{
-        @Override
-        public String toString() {
-            return "CUSTOMER";
-        }
-    }
+    ROLE_MANAGER,
+    ROLE_CUSTOMER
 }

--- a/src/main/java/com/zerobase/tablereservation/common/exceptions/ExceptionCode.java
+++ b/src/main/java/com/zerobase/tablereservation/common/exceptions/ExceptionCode.java
@@ -31,6 +31,7 @@ public enum ExceptionCode {
     REVIEW_NEEDED_VISIT(HttpStatus.BAD_REQUEST, "리뷰를 작성하려면 먼저 해당 매장에 방문해야합니다."),
     REVIEW_ALREADY_DONE(HttpStatus.BAD_REQUEST, "이미 작성된 리뷰가 존재합니다."),
     REVIEW_EMPTY(HttpStatus.BAD_REQUEST, "리뷰가 존재하지 않습니다."),
+    REVIEW_NON_AUTHORITY_DELETE(HttpStatus.BAD_REQUEST, "삭제할 권한이 없습니다."),
 
 
     /*

--- a/src/main/java/com/zerobase/tablereservation/src/model/ReviewDTO.java
+++ b/src/main/java/com/zerobase/tablereservation/src/model/ReviewDTO.java
@@ -1,0 +1,13 @@
+package com.zerobase.tablereservation.src.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReviewDTO {
+    Long reservationId;
+    Long restaurantId;
+    int rating;
+    String content;
+}

--- a/src/main/java/com/zerobase/tablereservation/src/model/ReviewDeleteDTO.java
+++ b/src/main/java/com/zerobase/tablereservation/src/model/ReviewDeleteDTO.java
@@ -5,9 +5,7 @@ import lombok.Data;
 
 @Data
 @Builder
-public class ReviewRegisterDTO {
-    Long reservationId;
+public class ReviewDeleteDTO {
+    Long reviewId;
     Long restaurantId;
-    int rating;
-    String content;
 }

--- a/src/main/java/com/zerobase/tablereservation/src/model/ReviewGetDTO.java
+++ b/src/main/java/com/zerobase/tablereservation/src/model/ReviewGetDTO.java
@@ -1,0 +1,23 @@
+package com.zerobase.tablereservation.src.model;
+
+import com.zerobase.tablereservation.src.persist.entity.Review;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReviewGetDTO {
+    Long reviewId;
+    int rating;
+    String content;
+
+    public static ReviewGetDTO fromEntity(Review review){
+        return ReviewGetDTO.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/zerobase/tablereservation/src/persist/ReservationRepository.java
+++ b/src/main/java/com/zerobase/tablereservation/src/persist/ReservationRepository.java
@@ -20,4 +20,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByCustomer_Id(Long id);
 
     Optional<Reservation> findByIdAndCustomer_Id(Long reservationId, Long customerId);
+
+    Optional<Reservation> findByReview_IdAndRestaurant_Id(Long reviewId, Long restaurantId);
 }

--- a/src/main/java/com/zerobase/tablereservation/src/persist/entity/Reservation.java
+++ b/src/main/java/com/zerobase/tablereservation/src/persist/entity/Reservation.java
@@ -31,9 +31,10 @@ public class Reservation extends BaseEntity{
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(orphanRemoval = true)
     @JoinColumn(name = "review_id")
     private Review review;
+    // 리뷰의 존재 이전에 예약이 존재할 수 없음.... 따라서 예약삭제->리뷰삭제가 강요되지 않음.
 
     public void checkVisit(){
         this.visit = true;

--- a/src/main/java/com/zerobase/tablereservation/src/persist/entity/Review.java
+++ b/src/main/java/com/zerobase/tablereservation/src/persist/entity/Review.java
@@ -1,6 +1,7 @@
 package com.zerobase.tablereservation.src.persist.entity;
 
 import com.zerobase.tablereservation.common.entity.BaseEntity;
+import com.zerobase.tablereservation.src.model.ReviewDTO;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
@@ -24,5 +25,10 @@ public class Review extends BaseEntity{
 
     public void setReservation(Reservation reservation) {
         this.reservation = reservation;
+    }
+
+    public void update(ReviewDTO dto) {
+        this.rating = dto.getRating();
+        this.content = dto.getContent();
     }
 }

--- a/src/main/java/com/zerobase/tablereservation/src/web/ReviewController.java
+++ b/src/main/java/com/zerobase/tablereservation/src/web/ReviewController.java
@@ -1,13 +1,12 @@
 package com.zerobase.tablereservation.src.web;
 
-import com.zerobase.tablereservation.src.model.ReviewRegisterDTO;
+import com.zerobase.tablereservation.src.model.ReviewDTO;
+import com.zerobase.tablereservation.src.model.ReviewDeleteDTO;
 import com.zerobase.tablereservation.src.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,22 +17,45 @@ public class ReviewController {
     /*
     review 등록
      */
+
     @PostMapping
-    public ResponseEntity<?> registerReview(@RequestBody ReviewRegisterDTO dto){
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<?> registerReview(@RequestBody ReviewDTO dto){
         reviewService.registerReview(dto);
-        reviewService.changeAverageRating(dto);
+        reviewService.changeAverageRating(dto.getRestaurantId());
         return ResponseEntity.ok("리뷰 등록에 성공했습니다.");
     }
 
     /*
     review 수정
      */
+    @PutMapping
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<?> updateReview(@RequestBody ReviewDTO dto){
+        reviewService.updateReview(dto);
+        reviewService.changeAverageRating(dto.getRestaurantId());
+        return ResponseEntity.ok("리뷰 수정에 성공했습니다.");
+    }
 
     /*
     review 제거
      */
+    @DeleteMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    public ResponseEntity<?> deleteReview(@RequestBody ReviewDeleteDTO dto){
+        reviewService.deleteReview(dto);
+        reviewService.changeAverageRating(dto.getRestaurantId());
+        return ResponseEntity.ok("리뷰 삭제에 성공했습니다.");
+    }
 
     /*
-    review 조회
+    특정 식당의 review 조회
      */
+
+    @GetMapping("/{restaurantId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER')")
+    public ResponseEntity<?> getReviews(@PathVariable Long restaurantId){
+        var result = reviewService.getReviews(restaurantId);
+        return ResponseEntity.ok(result);
+    }
 }


### PR DESCRIPTION
Changes
---
- Reservation, Review -> CascadeType.ALL 삭제
- SecurityConfig 수정 및 PreAuthorize로 메서드별 접근 권한 설정

Background
---
- SecurityConfig에서 접근 권한 설정을 해줘야 메서드 레벨에서 @PreAuthorize를 사용할 수 있음.
- 양방향 관계에서, 하위 엔티티 삭제를 편하게 하려면, 상위 엔티티에 OrphanRemoval=true를 주고, 외래키를 null로 바꾸면 자동으로 하위 엔티티가 삭제 됨.